### PR TITLE
fix: fastfive mobile bottom sheet open to shrink

### DIFF
--- a/floating-button-sdk.js
+++ b/floating-button-sdk.js
@@ -498,7 +498,7 @@ class FloatingButton {
         // Inject viewport meta tag to block ios zoom in
         this.injectViewport();
         // Chat being visible
-        this.enableChat(this.iframeHeightState || 'full');
+        this.enableChat(this.isMobileDevice ? 'shrink' : 'full');
         if (this.isMobileDevice) {history.pushState({ chatOpen: true }, '', window.location.href);}
 
         this.dimmedBackground?.addEventListener("click", (e) => {


### PR DESCRIPTION
fastfive 등에서 모바일 바텀 시트가 무조건 full height로 올라오는 현상 fix