### PR TITLE
fix: sdk godomall src change to prod sdk

### DIFF
--- a/sdk-godomall.js
+++ b/sdk-godomall.js
@@ -21,7 +21,7 @@
             // s.src = "https://sdk.gentooai.com/floating-button-sdk-godomall.js"; 
             // s.src = 'https://dev-sdk.gentooai.com/floating-button-sdk-godomall.js'; // dev
             // s.src = "./floating-button-sdk-godomall.js"; 
-            s.src = "https://dev-sdk.gentooai.com/dist/godomall/floating-sdk-godomall.js";
+            s.src = "https://sdk.gentooai.com/dist/godomall/floating-sdk-godomall.js";
             s.onload = () => { 
                 w.addEventListener("message", ()=>{})
             }; 


### PR DESCRIPTION
sdk-godomall.js 의 src 를 dev-sdk 에서 sdk로 변경