### PR TITLE
hotfix: Change hostSrc to dev-demo.gentooai.com for development environment

### DIFF
--- a/floating-button-sdk-shopifyTest.js
+++ b/floating-button-sdk-shopifyTest.js
@@ -83,8 +83,8 @@ class FloatingButton {
             window.location.hostname.includes("shopify-test") ||
             window.location.hostname === "gentoo-bom-shop3.myshopify.com"
         ) {
-            // 🧪 로컬 테스트 환경 설정 - localhost:3000에서 실행되는 채팅 웹 사용
-            this.hostSrc = "http://localhost:3000";
+            // 로컬 테스트 할 때만 localhost:3000에서 실행되는 채팅 웹 사용
+            this.hostSrc = "https://dev-demo.gentooai.com";
             this.domains = {
                 auth: "https://dev-api.gentooai.com/chat/api/v1/user",
                 log: "https://dev-api.gentooai.com/chat/api/v1/event/userEvent",


### PR DESCRIPTION
## Summary
- Change `this.hostSrc` from `http://localhost:3000` to `https://dev-demo.gentooai.com`
- Now iframe loads chat interface from dev environment instead of local
- Fixes chat URL generation for development stores

## Changes
- Updated hostSrc in development environment branch
- Chat iframe will now use `https://dev-demo.gentooai.com/chatroute/shopify?...`

🤖 Generated with [Claude Code](https://claude.ai/code)