### PR TITLE
feat: PDP 실험 제외 및 displayLocation 문서화

### DIFF
--- a/floating-button-sdk-shopifyTest.js
+++ b/floating-button-sdk-shopifyTest.js
@@ -196,6 +196,9 @@ class FloatingButton {
             }
 
             if (this.isExperimentTarget && !this.gentooSessionData?.redirectState) {
+                if (this.displayLocation === 'PRODUCT_DETAIL') {
+                    return;
+                }
                 this.experimentData = await this.fetchShopifyExperimentData(this.partnerId);
                 
                 if (this.experimentData && this.experimentData.comments && this.experimentData.comments.length > 0) {
@@ -203,11 +206,6 @@ class FloatingButton {
                     this.selectedCommentSet = this.experimentData.comments[randomIndex];
                     
                     this.floatingData.comment = this.selectedCommentSet.floating;
-                    
-                    console.log('t-floating', { 
-                        floating: this.selectedCommentSet.floating,
-                        greeting: this.selectedCommentSet.greeting
-                    });
                 }
             }
 


### PR DESCRIPTION
## Summary
- PDP(상품 상세페이지)에서 플로팅 실험 적용 제외하여 안정적인 구매 전환 보장
- displayLocation 시스템 종합 문서화 및 Shopify 구현 방식 정정
- 백엔드 공식 enum과 SDK 전용 값 구분 정리

## Test plan
- [ ] Shopify 테스트 스토어에서 PDP 접근 시 실험 플로팅 문구 표시되지 않는지 확인
- [ ] HOME, PRODUCT_LIST 페이지에서는 여전히 실험 문구 정상 작동하는지 확인
- [ ] displayLocation 자동 감지 로직이 각 플랫폼에서 정상 작동하는지 확인

🤖 Generated with [Claude Code](https://claude.ai/code)