### PR TITLE
hotfix: PDP 플로팅 버튼 표시 로직 수정

### DIFF
--- a/floating-button-sdk-shopifyTest.js
+++ b/floating-button-sdk-shopifyTest.js
@@ -196,16 +196,15 @@ class FloatingButton {
             }
 
             if (this.isExperimentTarget && !this.gentooSessionData?.redirectState) {
-                if (this.displayLocation === 'PRODUCT_DETAIL') {
-                    return;
-                }
-                this.experimentData = await this.fetchShopifyExperimentData(this.partnerId);
-                
-                if (this.experimentData && this.experimentData.comments && this.experimentData.comments.length > 0) {
-                    const randomIndex = Math.floor(Math.random() * this.experimentData.comments.length);
-                    this.selectedCommentSet = this.experimentData.comments[randomIndex];
+                if (this.displayLocation !== 'PRODUCT_DETAIL') {
+                    this.experimentData = await this.fetchShopifyExperimentData(this.partnerId);
                     
-                    this.floatingData.comment = this.selectedCommentSet.floating;
+                    if (this.experimentData && this.experimentData.comments && this.experimentData.comments.length > 0) {
+                        const randomIndex = Math.floor(Math.random() * this.experimentData.comments.length);
+                        this.selectedCommentSet = this.experimentData.comments[randomIndex];
+                        
+                        this.floatingData.comment = this.selectedCommentSet.floating;
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
- PRODUCT_DETAIL 페이지에서 플로팅 버튼이 아예 표시되지 않는 문제 수정
- 조기 리턴 대신 조건부 실행으로 변경하여 UI 생성 로직 정상 실행 보장
- PDP에서는 기본 플로팅 문구, HOME/PRODUCT_LIST에서는 실험 문구 유지

## Problem
기존 코드에서 `displayLocation === 'PRODUCT_DETAIL'`일 때 `return`으로 인해 `createUIElements()` 호출이 차단되어 플로팅 버튼 자체가 표시되지 않음

## Solution  
실험 로직만 조건부로 실행하고 UI 생성은 정상 진행되도록 수정

## Test plan
- [ ] PDP에서 플로팅 버튼이 정상 표시되는지 확인 (기본 문구)
- [ ] HOME/PRODUCT_LIST에서 실험 문구가 정상 작동하는지 확인
- [ ] 채팅 기능이 모든 페이지에서 정상 작동하는지 확인

🤖 Generated with [Claude Code](https://claude.ai/code)