### PR TITLE
플로팅 메시지 타이핑 애니메이션 충돌 문제 해결

### DIFF
--- a/floating-button-sdk-shopifyTest.js
+++ b/floating-button-sdk-shopifyTest.js
@@ -67,6 +67,7 @@ class FloatingButton {
         this.availableComments = null;
         this.selectedCommentSet = null;
         this.floatingMessageIntervalId = null;
+        this.currentTypingTimeoutId = null;
         this.warningMessage;
         this.warningActivated;
         this.floatingData;
@@ -474,7 +475,8 @@ class FloatingButton {
         if (this.floatingClicked || this.isDestroyed || !this.floatingContainer)
             return;
 
-        // 기존 expandedButton 정리 (새로운 메시지용) - 안전한 제거
+        // 기존 타이핑 애니메이션과 expandedButton 정리 (새로운 메시지용) - 안전한 제거
+        this.clearCurrentTyping();
         this.safeRemoveExpandedButton();
 
         // 🗨️ 플로팅 문구 UI 요소 생성 (기존 로직 그대로)
@@ -511,10 +513,15 @@ class FloatingButton {
                         this.expandedText.innerText += messageText[i];
                         i++;
                         if (i < messageText.length && !this.isDestroyed) {
-                            setTimeout(addLetter, typeSpeed);
+                            // 다음 타이핑을 예약하고 ID 저장 (충돌 방지)
+                            this.currentTypingTimeoutId = setTimeout(addLetter, typeSpeed);
+                        } else {
+                            // 타이핑 완료시 ID 초기화
+                            this.currentTypingTimeoutId = null;
                         }
                     } catch (error) {
                         console.warn('Error during typing animation:', error);
+                        this.currentTypingTimeoutId = null;
                     }
                 }
             };
@@ -551,7 +558,18 @@ class FloatingButton {
         this.createFloatingMessage(this.selectedCommentSet.floating, false);
     }
 
+    // 현재 진행 중인 타이핑 애니메이션 중단
+    clearCurrentTyping() {
+        if (this.currentTypingTimeoutId) {
+            clearTimeout(this.currentTypingTimeoutId);
+            this.currentTypingTimeoutId = null;
+        }
+    }
+
     safeRemoveExpandedButton() {
+        // 타이핑 애니메이션 먼저 중단
+        this.clearCurrentTyping();
+        
         try {
             if (this.expandedButton && 
                 this.expandedButton.parentNode && 
@@ -875,6 +893,9 @@ class FloatingButton {
             clearInterval(this.floatingMessageIntervalId);
             this.floatingMessageIntervalId = null;
         }
+        
+        // 타이핑 애니메이션 정리
+        this.clearCurrentTyping();
         
         // 이벤트 리스너 정리
         window.removeEventListener('pagehide', this.handlePageUnload);


### PR DESCRIPTION
## 🐛 문제 상황

플로팅 메시지 시스템에서 **텍스트가 뒤섞이는 심각한 UI 버그**가 발생하고 있었습니다.

### 발생 조건
- 플로팅 메시지가 타이핑 애니메이션 진행 중일 때
- 30초 interval로 새로운 플로팅 메시지가 시작되는 경우
- 두 개의 독립적인 `setTimeout` 체인이 같은 DOM 요소(`this.expandedText`)에서 동시 실행

### 문제 시나리오
```
시간 0초: "Hello World!" 타이핑 시작 (2초 소요 예정)
시간 1초: "Hell" 까지 표시됨
시간 10초: 새 메시지 "안녕하세요!" 강제 시작
         ↓
결과: "Hell안녕o W하o세r요l!d!" (텍스트 혼합)
```

## 🔧 해결 방법

### 핵심 아이디어: **setTimeout ID 추적 시스템**

1. **타이핑 애니메이션 추적**
   - `this.currentTypingTimeoutId` 변수로 현재 진행 중인 타이핑 추적
   - 각 `setTimeout` 호출 시 ID 저장

2. **안전한 중단 메커니즘**
   - `clearCurrentTyping()` 메서드로 진행 중인 타이핑 중단
   - 새 메시지 시작 전 기존 애니메이션 완전 정리

3. **메모리 누수 방지**
   - `cleanup()` 메서드에서도 타이핑 애니메이션 정리
   - DOM 제거와 함께 관련 타이머도 모두 정리

## 📋 변경사항

### 1. 생성자에 타이머 관리 변수 추가
```javascript
this.currentTypingTimeoutId = null;
```

### 2. createFloatingMessage 개선
- 기존 타이핑 중단: `this.clearCurrentTyping()`
- setTimeout ID 저장으로 추적 가능하게 개선
- 타이핑 완료 시 ID 초기화

### 3. 안전한 정리 메서드 추가
```javascript
clearCurrentTyping() {
    if (this.currentTypingTimeoutId) {
        clearTimeout(this.currentTypingTimeoutId);
        this.currentTypingTimeoutId = null;
    }
}
```

### 4. 기존 메서드 강화
- `safeRemoveExpandedButton()`: DOM 제거 전 타이핑 중단
- `cleanup()`: 모든 리소스와 함께 타이핑 애니메이션도 정리

## ✅ 테스트 결과

- ✅ 텍스트 혼합 현상 완전 해결
- ✅ 메모리 누수 방지로 성능 개선  
- ✅ 각 플로팅 메시지가 독립적으로 안전하게 실행
- ✅ 기존 기능에 영향 없음

## 🎯 영향도

- **사용자 경험**: 플로팅 메시지 텍스트가 정상적으로 표시
- **성능**: setTimeout 누수 방지로 메모리 사용량 개선
- **안정성**: 예상치 못한 타이밍 이슈 방지

🎯 Generated with [Claude Code](https://claude.ai/code)