### PR TITLE
feat: add memberOnlyAccess guest access block across SDKs

### DIFF
--- a/sdk-imweb-test.js
+++ b/sdk-imweb-test.js
@@ -1,0 +1,47 @@
+(
+    function (global, document) {
+        var w = global;
+        if (w.GentooIO) {
+            return w.console.error("GentooIO script included twice");
+        };
+        var ge = function () {
+            ge.c(arguments);
+        };
+        ge.q = [];
+        ge.c = function (args) {
+            ge.q.push(args)
+        };
+        w.GentooIO = ge;
+        function l() {
+            if (w.GentooIOInitialized) { return };
+            w.GentooIOInitialized = true;
+            var s = document.createElement("script");
+            s.type = "text/javascript";
+            s.async = true;
+            var isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent) || window.innerWidth < 601;
+            // 로컬 dev 환경에서는 로컬 dist 번들 로드, 그 외는 CDN
+            if (window.location.hostname === "127.0.0.1" || window.location.hostname === "localhost") {
+                s.src = isMobile
+                    ? "./dist/imweb-modal/floating-imweb-modal.js"
+                    : "./dist/imweb/floating-imweb.js";
+            } else {
+                s.src = isMobile
+                    ? "https://sdk.gentooai.com/dist/imweb-modal/floating-imweb-modal.js"
+                    : "https://sdk.gentooai.com/dist/imweb/floating-imweb.js";
+            }
+            s.onload = () => {
+                w.addEventListener("message", () => { })
+            };
+            var x = document.getElementsByTagName("script")[0];
+            if (x.parentNode) {
+                x.parentNode.insertBefore(s, x)
+            };
+        };
+        if (document.readyState === "complete") {
+            l();
+        } else {
+            w.addEventListener("DOMContentLoaded", l);
+            w.addEventListener("load", l);
+        };
+    }
+)(window, document);

--- a/src/floating-sdk-cafe24-glacier.css
+++ b/src/floating-sdk-cafe24-glacier.css
@@ -489,3 +489,64 @@
 .event-disabled {
     pointer-events: none;
 }
+
+.guest-access-block {
+    width: 100%;
+    height: calc(100% - 56px);
+    box-sizing: border-box;
+    padding: 32px 24px;
+    background: #fff;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+}
+
+.guest-access-block-md {
+    height: calc(100% - 44px);
+}
+
+.guest-access-block-title {
+    font-family: "pretendard";
+    font-size: 18px;
+    font-weight: 700;
+    line-height: 22px;
+    letter-spacing: -0.025em;
+    color: #222;
+    margin: 0 0 8px 0;
+}
+
+.guest-access-block-description {
+    font-family: "pretendard";
+    font-size: 14px;
+    font-weight: 400;
+    line-height: 20px;
+    letter-spacing: -0.025em;
+    color: #666;
+    margin: 0 0 24px 0;
+    white-space: pre-line;
+}
+
+.guest-access-block-login-button {
+    font-family: "pretendard";
+    font-size: 14px;
+    font-weight: 600;
+    line-height: 17px;
+    letter-spacing: -0.025em;
+    color: #fff;
+    background: #222;
+    border: none;
+    border-radius: 8px;
+    padding: 12px 28px;
+    cursor: pointer;
+    transition: background 0.2s ease;
+}
+
+.guest-access-block-login-button:hover {
+    background: #444;
+}
+
+.guest-access-block-iframe-hide {
+    display: none !important;
+}

--- a/src/floating-sdk-cafe24-glacier.js
+++ b/src/floating-sdk-cafe24-glacier.js
@@ -1,11 +1,12 @@
 import './floating-sdk-cafe24-glacier.css';
-import { 
-    getChatbotData, 
-    postChatUserId, 
-    getFloatingData, 
-    getPartnerId, 
-    postChatEventLog 
+import {
+    getChatbotData,
+    postChatUserId,
+    getFloatingData,
+    getPartnerId,
+    postChatEventLog
 } from './apis/chatConfig';
+import { buildGuestAccessBlockView, isGuestAccessBlocked } from './utils/guestAccessBlock';
 
 class FloatingButton {
     constructor(props) {
@@ -115,8 +116,10 @@ class FloatingButton {
                     .then(res => {
                         if (res.id.member_id) {
                             this.cafe24UserId = res.id.member_id;
+                            this.userType = "member";
                         } else {
                             this.cafe24UserId = res.id['guest_id'];
+                            this.userType = "guest";
                         }
 
                         // 1. chatUserId 먼저 받아오기 (for floating/chatbot AB test)
@@ -142,6 +145,9 @@ class FloatingButton {
                         this.warningActivated = warningMessageData?.activated;
                         this.floatingZoom = floatingZoom?.activated;
                         this.floatingAvatar = chatbotData?.avatar;
+                        const memberOnlyAccessData = chatbotData?.experimentalData?.find(item => item.key === "memberOnlyAccess");
+                        this.memberOnlyAccessActivated = memberOnlyAccessData?.activated;
+                        this.memberOnlyAccessLoginUrl = memberOnlyAccessData?.value;
                         resolve();
                     })
                     .catch(error => {
@@ -255,7 +261,11 @@ class FloatingButton {
         this.footerText.className = "chat-footer-text";
         this.footer.appendChild(this.footerText);
         this.iframe = document.createElement("iframe");
-        this.iframe.src = this.chatUrl;
+        if (isGuestAccessBlocked(this)) {
+            this.iframe.style.display = 'none';
+        } else {
+            this.iframe.src = this.chatUrl;
+        }
         if (this.floatingAvatar?.floatingAsset || this.floatingData.imageUrl.includes('gentoo-anime-web-default.lottie')) {
             const player = document.createElement('dotlottie-wc');
             player.setAttribute('autoplay', '');
@@ -305,7 +315,9 @@ class FloatingButton {
 
         this.iframeContainer.appendChild(this.chatHeader);
         this.iframeContainer.appendChild(this.iframe);
-        if (this.warningActivated) {
+        if (isGuestAccessBlocked(this)) {
+            this.iframeContainer.appendChild(buildGuestAccessBlockView(this.memberOnlyAccessLoginUrl, { isSmallResolution: this.isSmallResolution }));
+        } else if (this.warningActivated) {
             this.footerText.innerText = this.warningMessage;
             this.iframeContainer.appendChild(this.footer);
         }

--- a/src/floating-sdk-cafe24-modal.js
+++ b/src/floating-sdk-cafe24-modal.js
@@ -182,6 +182,9 @@ class FloatingButton {
                         this.floatingZoom = floatingZoom?.activated;
                         this.floatingAvatar = chatbotData?.avatar;
                         this.csInquiry = csInquiry?.activated;
+                        const memberOnlyAccessData = chatbotData?.experimentalData?.find(item => item.key === "memberOnlyAccess");
+                        this.memberOnlyAccessActivated = memberOnlyAccessData?.activated;
+                        this.memberOnlyAccessLoginUrl = memberOnlyAccessData?.value;
                         resolve();
                     })
                     .catch(error => {

--- a/src/floating-sdk-godomall-modal.js
+++ b/src/floating-sdk-godomall-modal.js
@@ -163,6 +163,9 @@ class FloatingButton {
                     this.floatingZoom = floatingZoom?.activated;
                     const csInquiry = chatbotData?.experimentalData?.find(item => item.key === "csInquiry");
                     this.csInquiry = csInquiry?.activated;
+                    const memberOnlyAccessData = chatbotData?.experimentalData?.find(item => item.key === "memberOnlyAccess");
+                    this.memberOnlyAccessActivated = memberOnlyAccessData?.activated;
+                    this.memberOnlyAccessLoginUrl = memberOnlyAccessData?.value;
                     resolve();
                 })
                 .catch(error => {

--- a/src/floating-sdk-godomall.css
+++ b/src/floating-sdk-godomall.css
@@ -525,3 +525,64 @@
 .event-disabled {
     pointer-events: none;
 }
+
+.guest-access-block {
+    width: 100%;
+    height: calc(100% - 56px);
+    box-sizing: border-box;
+    padding: 32px 24px;
+    background: #fff;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+}
+
+.guest-access-block-md {
+    height: calc(100% - 44px);
+}
+
+.guest-access-block-title {
+    font-family: "pretendard";
+    font-size: 18px;
+    font-weight: 700;
+    line-height: 22px;
+    letter-spacing: -0.025em;
+    color: #222;
+    margin: 0 0 8px 0;
+}
+
+.guest-access-block-description {
+    font-family: "pretendard";
+    font-size: 14px;
+    font-weight: 400;
+    line-height: 20px;
+    letter-spacing: -0.025em;
+    color: #666;
+    margin: 0 0 24px 0;
+    white-space: pre-line;
+}
+
+.guest-access-block-login-button {
+    font-family: "pretendard";
+    font-size: 14px;
+    font-weight: 600;
+    line-height: 17px;
+    letter-spacing: -0.025em;
+    color: #fff;
+    background: #222;
+    border: none;
+    border-radius: 8px;
+    padding: 12px 28px;
+    cursor: pointer;
+    transition: background 0.2s ease;
+}
+
+.guest-access-block-login-button:hover {
+    background: #444;
+}
+
+.guest-access-block-iframe-hide {
+    display: none !important;
+}

--- a/src/floating-sdk-godomall.js
+++ b/src/floating-sdk-godomall.js
@@ -9,6 +9,7 @@ import {
     generateGuestUserToken
 } from './apis/chatConfig';
 import { applyCanvasObjectFit } from './utils/floatingSdkUtils';
+import { buildGuestAccessBlockView, isGuestAccessBlocked } from './utils/guestAccessBlock';
 
 class FloatingButton {
     constructor(props) {
@@ -199,6 +200,9 @@ class FloatingButton {
                     this.floatingAvatar = chatbotData?.avatar;
                     const floatingZoom = chatbotData?.experimentalData?.find(item => item.key === "floatingZoom");
                     this.floatingZoom = floatingZoom?.activated;
+                    const memberOnlyAccessData = chatbotData?.experimentalData?.find(item => item.key === "memberOnlyAccess");
+                    this.memberOnlyAccessActivated = memberOnlyAccessData?.activated;
+                    this.memberOnlyAccessLoginUrl = memberOnlyAccessData?.value;
                     resolve();
                 })
                 .catch(error => {
@@ -315,7 +319,11 @@ class FloatingButton {
         this.footerText.className = "chat-footer-text";
         this.footer.appendChild(this.footerText);
         this.iframe = document.createElement("iframe");
-        this.iframe.src = this.chatUrl;
+        if (isGuestAccessBlocked(this)) {
+            this.iframe.style.display = 'none';
+        } else {
+            this.iframe.src = this.chatUrl;
+        }
 
         // bootconfig floating imageurl OR floatingavatar floatingasset 중 하나
         const bootImage = this.bootConfig?.floating?.button?.imageUrl;
@@ -374,7 +382,9 @@ class FloatingButton {
 
         this.iframeContainer.appendChild(this.chatHeader);
         this.iframeContainer.appendChild(this.iframe);
-        if (this.warningActivated) {
+        if (isGuestAccessBlocked(this)) {
+            this.iframeContainer.appendChild(buildGuestAccessBlockView(this.memberOnlyAccessLoginUrl, { isSmallResolution: this.isSmallResolution }));
+        } else if (this.warningActivated) {
             this.footerText.innerText = this.warningMessage;
             this.iframeContainer.appendChild(this.footer);
         }

--- a/src/floating-sdk-imweb-modal.js
+++ b/src/floating-sdk-imweb-modal.js
@@ -102,7 +102,13 @@ class FloatingButton {
                 }
             }
 
-            getImwebPartnerId(imwebMallUnitCode)
+            if (props.testPartnerId) {
+                console.warn('[Gentoo SDK] testPartnerId is for testing only — skipping getImwebPartnerId lookup');
+            }
+            const partnerIdPromise = props.testPartnerId
+                ? Promise.resolve(props.testPartnerId)
+                : getImwebPartnerId(imwebMallUnitCode);
+            partnerIdPromise
                 .then((partnerId) => {
                     this.imwebUserId = imwebMemberUid;
                     this.partnerId = partnerId;
@@ -133,6 +139,9 @@ class FloatingButton {
                     this.floatingZoom = floatingZoom?.activated;
                     const csInquiry = chatbotData?.experimentalData?.find(item => item.key === "csInquiry");
                     this.csInquiry = csInquiry?.activated;
+                    const memberOnlyAccessData = chatbotData?.experimentalData?.find(item => item.key === "memberOnlyAccess");
+                    this.memberOnlyAccessActivated = memberOnlyAccessData?.activated;
+                    this.memberOnlyAccessLoginUrl = memberOnlyAccessData?.value;
                     resolve();
                 })
                 .catch(error => {

--- a/src/floating-sdk-imweb.css
+++ b/src/floating-sdk-imweb.css
@@ -528,3 +528,64 @@
 .event-disabled {
     pointer-events: none;
 }
+
+.guest-access-block {
+    width: 100%;
+    height: calc(100% - 56px);
+    box-sizing: border-box;
+    padding: 32px 24px;
+    background: #fff;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+}
+
+.guest-access-block-md {
+    height: calc(100% - 44px);
+}
+
+.guest-access-block-title {
+    font-family: "pretendard";
+    font-size: 18px;
+    font-weight: 700;
+    line-height: 22px;
+    letter-spacing: -0.025em;
+    color: #222;
+    margin: 0 0 8px 0;
+}
+
+.guest-access-block-description {
+    font-family: "pretendard";
+    font-size: 14px;
+    font-weight: 400;
+    line-height: 20px;
+    letter-spacing: -0.025em;
+    color: #666;
+    margin: 0 0 24px 0;
+    white-space: pre-line;
+}
+
+.guest-access-block-login-button {
+    font-family: "pretendard";
+    font-size: 14px;
+    font-weight: 600;
+    line-height: 17px;
+    letter-spacing: -0.025em;
+    color: #fff;
+    background: #222;
+    border: none;
+    border-radius: 8px;
+    padding: 12px 28px;
+    cursor: pointer;
+    transition: background 0.2s ease;
+}
+
+.guest-access-block-login-button:hover {
+    background: #444;
+}
+
+.guest-access-block-iframe-hide {
+    display: none !important;
+}

--- a/src/floating-sdk-imweb.js
+++ b/src/floating-sdk-imweb.js
@@ -9,6 +9,7 @@ import {
     generateGuestUserToken
 } from './apis/chatConfig';
 import { applyCanvasObjectFit } from './utils/floatingSdkUtils';
+import { buildGuestAccessBlockView, isGuestAccessBlocked } from './utils/guestAccessBlock';
 
 class FloatingButton {
     constructor(props) {
@@ -136,7 +137,13 @@ class FloatingButton {
                 }
             }
 
-            getImwebPartnerId(imwebMallUnitCode)
+            if (props.testPartnerId) {
+                console.warn('[Gentoo SDK] testPartnerId is for testing only — skipping getImwebPartnerId lookup');
+            }
+            const partnerIdPromise = props.testPartnerId
+                ? Promise.resolve(props.testPartnerId)
+                : getImwebPartnerId(imwebMallUnitCode);
+            partnerIdPromise
                 .then((partnerId) => {
                     this.imwebUserId = imwebMemberUid;
                     this.partnerId = partnerId;
@@ -163,6 +170,9 @@ class FloatingButton {
                     this.floatingAvatar = chatbotData?.avatar;
                     const floatingZoom = chatbotData?.experimentalData?.find(item => item.key === "floatingZoom");
                     this.floatingZoom = floatingZoom?.activated;
+                    const memberOnlyAccessData = chatbotData?.experimentalData?.find(item => item.key === "memberOnlyAccess");
+                    this.memberOnlyAccessActivated = memberOnlyAccessData?.activated;
+                    this.memberOnlyAccessLoginUrl = memberOnlyAccessData?.value;
                     resolve();
                 })
                 .catch(error => {
@@ -279,7 +289,11 @@ class FloatingButton {
         this.footerText.className = "chat-footer-text";
         this.footer.appendChild(this.footerText);
         this.iframe = document.createElement("iframe");
-        this.iframe.src = this.chatUrl;
+        if (isGuestAccessBlocked(this)) {
+            this.iframe.style.display = 'none';
+        } else {
+            this.iframe.src = this.chatUrl;
+        }
 
         // bootconfig floating imageurl OR floatingavatar floatingasset 중 하나
         const bootImage = this.bootConfig?.floating?.button?.imageUrl;
@@ -338,7 +352,9 @@ class FloatingButton {
 
         this.iframeContainer.appendChild(this.chatHeader);
         this.iframeContainer.appendChild(this.iframe);
-        if (this.warningActivated) {
+        if (isGuestAccessBlocked(this)) {
+            this.iframeContainer.appendChild(buildGuestAccessBlockView(this.memberOnlyAccessLoginUrl, { isSmallResolution: this.isSmallResolution }));
+        } else if (this.warningActivated) {
             this.footerText.innerText = this.warningMessage;
             this.iframeContainer.appendChild(this.footer);
         }

--- a/src/floating-sdk-modal.css
+++ b/src/floating-sdk-modal.css
@@ -777,3 +777,64 @@ div.chat-send-button {
 .event-disabled {
     pointer-events: none;
 }
+
+.guest-access-block {
+    width: 100%;
+    height: calc(100% - 56px);
+    box-sizing: border-box;
+    padding: 32px 24px;
+    background: #fff;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+}
+
+.guest-access-block-md {
+    height: calc(100% - 44px);
+}
+
+.guest-access-block-title {
+    font-family: "pretendard";
+    font-size: 18px;
+    font-weight: 700;
+    line-height: 22px;
+    letter-spacing: -0.025em;
+    color: #222;
+    margin: 0 0 8px 0;
+}
+
+.guest-access-block-description {
+    font-family: "pretendard";
+    font-size: 14px;
+    font-weight: 400;
+    line-height: 20px;
+    letter-spacing: -0.025em;
+    color: #666;
+    margin: 0 0 24px 0;
+    white-space: pre-line;
+}
+
+.guest-access-block-login-button {
+    font-family: "pretendard";
+    font-size: 14px;
+    font-weight: 600;
+    line-height: 17px;
+    letter-spacing: -0.025em;
+    color: #fff;
+    background: #222;
+    border: none;
+    border-radius: 8px;
+    padding: 12px 28px;
+    cursor: pointer;
+    transition: background 0.2s ease;
+}
+
+.guest-access-block-login-button:hover {
+    background: #444;
+}
+
+.guest-access-block-iframe-hide {
+    display: none !important;
+}

--- a/src/floating-sdk-shopify-modal.js
+++ b/src/floating-sdk-shopify-modal.js
@@ -77,6 +77,7 @@ class FloatingButton {
         this.authCode = props.authCode;
         this.itemId = props.itemId || null;
         this.displayLocation = props.displayLocation || "HOME";
+        this.userType = props.userType;
         this.udid = props.udid || "";
         this.utm = props.utm;
         this.gentooSessionData = JSON.parse(sessionStorage.getItem('gentoo')) || {};
@@ -154,6 +155,9 @@ class FloatingButton {
                     this.warningMessage = warningMessageData?.extra?.message;
                     this.warningActivated = warningMessageData?.activated;
                     this.csInquiry = csInquiry?.activated;
+                    const memberOnlyAccessData = this.chatbotData?.experimentalData?.find(item => item.key === "memberOnlyAccess");
+                    this.memberOnlyAccessActivated = memberOnlyAccessData?.activated;
+                    this.memberOnlyAccessLoginUrl = memberOnlyAccessData?.value;
                 }),
                 getFloatingData(this.partnerId, this.displayLocation, this.itemId, this.chatUserId).then((res) => {
                     if (!res) throw new Error("Failed to fetch floating data");

--- a/src/utils/createUIElementsModal.js
+++ b/src/utils/createUIElementsModal.js
@@ -9,6 +9,7 @@ import {
     checkSDKExists,
     applyCanvasObjectFit
 } from "./floatingSdkUtils";
+import { buildGuestAccessBlockView, isGuestAccessBlocked } from "./guestAccessBlock";
 
 // --- Small helpers for readability ---
 const hasValidChatbotData = (chatbotData) => {
@@ -150,7 +151,11 @@ export const createUIElementsModal = (
 
     /* [Iframe] */
     context.iframe = document.createElement("iframe");
-    context.iframe.src = context.chatUrl;
+    if (isGuestAccessBlocked(context)) {
+        context.iframe.style.display = 'none';
+    } else {
+        context.iframe.src = context.chatUrl;
+    }
 
     /* [Chat Header] */
     context.chatHeader = document.createElement("div");
@@ -259,7 +264,9 @@ export const createUIElementsModal = (
             context.examFloatingGroup.appendChild(examFloatingButton);
         });
         context.inputContainer.appendChild(context.examFloatingGroup);
-        document.body.appendChild(context.inputContainer);
+        if (!isGuestAccessBlocked(context)) {
+            document.body.appendChild(context.inputContainer);
+        }
     } else {
         /* 데스크탑 채팅창 일반 UI 생성 */
         /* [Iframe] */
@@ -280,7 +287,9 @@ export const createUIElementsModal = (
 
     context.iframeContainer.appendChild(context.chatHeader);
     context.iframeContainer.appendChild(context.iframe);
-    if (context.warningActivated) {
+    if (isGuestAccessBlocked(context)) {
+        context.iframeContainer.appendChild(buildGuestAccessBlockView(context.memberOnlyAccessLoginUrl, { isSmallResolution: context.isSmallResolution }));
+    } else if (context.warningActivated) {
         context.footerText.innerText = context.warningMessage;
         context.iframeContainer.appendChild(context.footer);
     }

--- a/src/utils/guestAccessBlock.js
+++ b/src/utils/guestAccessBlock.js
@@ -1,0 +1,36 @@
+export const isGuestAccessBlocked = (context) => {
+    return context?.userType === 'guest'
+        && Boolean(context?.memberOnlyAccessActivated);
+};
+
+export const buildGuestAccessBlockView = (loginUrl, options = {}) => {
+    const { isSmallResolution = false, lang = 'ko' } = options;
+
+    const wrapper = document.createElement('div');
+    wrapper.className = `guest-access-block${isSmallResolution ? ' guest-access-block-md' : ''}`;
+    wrapper.setAttribute('data-gentoo-sdk', 'true');
+
+    const title = document.createElement('p');
+    title.className = 'guest-access-block-title';
+    title.innerText = lang === 'ko' ? '로그인 후 사용 가능합니다' : 'Login required';
+
+    const description = document.createElement('p');
+    description.className = 'guest-access-block-description';
+    description.innerText = lang === 'ko'
+        ? '로그인하시면 AI 챗봇을 이용하실 수 있어요.'
+        : 'Log in to use the AI chatbot.';
+
+    const loginButton = document.createElement('button');
+    loginButton.type = 'button';
+    loginButton.className = 'guest-access-block-login-button';
+    loginButton.innerText = lang === 'ko' ? '로그인 하기' : 'Log in';
+    loginButton.addEventListener('click', () => {
+        window.location.href = loginUrl || window.location.href;
+    });
+
+    wrapper.appendChild(title);
+    wrapper.appendChild(description);
+    wrapper.appendChild(loginButton);
+
+    return wrapper;
+};

--- a/testImweb.html
+++ b/testImweb.html
@@ -1,0 +1,222 @@
+<!DOCTYPE html>
+<html lang="ko">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Imweb SDK Test - Guest Access Block</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Pretendard", sans-serif;
+            margin: 0;
+            padding: 24px;
+            background: #fafafa;
+        }
+
+        .test-controls {
+            background: #fff;
+            border: 1px solid #e1e1e1;
+            border-radius: 8px;
+            padding: 20px;
+            margin-bottom: 24px;
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+        }
+
+        .test-controls h2 {
+            margin: 0 0 12px 0;
+            font-size: 18px;
+        }
+
+        .current-state {
+            display: inline-block;
+            padding: 4px 12px;
+            border-radius: 4px;
+            background: #f0f0f0;
+            font-family: monospace;
+            margin-bottom: 12px;
+        }
+
+        .test-controls button {
+            padding: 10px 16px;
+            margin: 4px 8px 4px 0;
+            border: 1px solid #222;
+            background: #fff;
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 14px;
+        }
+
+        .test-controls button.active {
+            background: #222;
+            color: #fff;
+        }
+
+        .test-controls button:hover {
+            background: #f5f5f5;
+        }
+
+        .test-controls button.active:hover {
+            background: #444;
+        }
+
+        .test-controls .desc {
+            font-size: 13px;
+            color: #666;
+            margin: 8px 0;
+        }
+
+        .sample {
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+        }
+
+        .sample .box {
+            background: skyblue;
+            height: 200px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-weight: 600;
+        }
+
+        .sample .box.tall {
+            height: 600px;
+        }
+    </style>
+</head>
+
+<body>
+    <div class="test-controls">
+        <h2>Imweb SDK Test — Guest Access Block</h2>
+        <div class="current-state" id="state-display"></div>
+        <p class="desc">URL 쿼리 파라미터로 제어: <code>?mode=guestBlocked|guest|member</code>, <code>?partnerId=...</code> (테스트 스토어 partnerId). 로그인 URL은 백엔드 <code>experimentalData[memberOnlyAccess].value</code> 그대로 통과. 비어있으면 SDK가 현재 페이지 URL로 fallback 처리.</p>
+        <button data-mode="guestBlocked" onclick="setMode('guestBlocked')">Guest + Block ON</button>
+        <button data-mode="guest" onclick="setMode('guest')">Guest + Block OFF</button>
+        <button data-mode="member" onclick="setMode('member')">Member</button>
+        <p class="desc">검증 포인트:</p>
+        <ul class="desc">
+            <li><strong>Guest + Block ON</strong>: 플로팅 버튼 클릭 시 채팅 자리에 "로그인 후 사용 가능합니다" 화면 + "로그인 하기" 버튼이 표시</li>
+            <li><strong>Guest + Block OFF</strong>: 일반 채팅 iframe이 로드 (chat web 응답에 따라 달라질 수 있음)</li>
+            <li><strong>Member</strong>: 일반 채팅이 정상 노출, 블락 화면 없음</li>
+        </ul>
+    </div>
+
+    <div class="sample">
+        <div class="box">상품 카드 영역 (mock)</div>
+        <div class="box">콘텐츠 영역</div>
+        <div class="box tall">긴 스크롤 영역</div>
+    </div>
+
+    <script>
+        // ===== Test mode handling =====
+        const params = new URLSearchParams(window.location.search);
+        const TEST_MODE = params.get('mode') || 'guestBlocked';
+        const TEST_PARTNER_ID = params.get('partnerId') || '68f6d753165ff8db3d070faf';
+
+        document.getElementById('state-display').innerText =
+            `mode = ${TEST_MODE}    partnerId = ${TEST_PARTNER_ID}`;
+        document.querySelectorAll('[data-mode]').forEach(btn => {
+            if (btn.dataset.mode === TEST_MODE) btn.classList.add('active');
+        });
+
+        function setMode(mode) {
+            const url = new URL(window.location.href);
+            url.searchParams.set('mode', mode);
+            // 매 전환마다 sessionStorage clear (gentooGuest, gentoo 등)
+            try { sessionStorage.clear(); } catch (e) { }
+            window.location.href = url.toString();
+        }
+
+        // ===== Imweb identity =====
+        // testPartnerId 사용으로 UNIT_CODE 기반 lookup은 스킵됨. MEMBER_UID만 게스트/회원 판별에 영향
+        window.UNIT_CODE = 'test-mall-unit-code';
+        window.MEMBER_UID = TEST_MODE === 'member' ? 'test-imweb-member-uid-001' : '';
+
+        // ===== Fetch wrapper =====
+        // chatbot/bootconfig/floating 응답에 memberOnlyAccess 주입 + 누락 필드 폴백
+        // 그 외 endpoint(api/v1/user, api/v1/event/* 등)는 real backend로 통과
+        const originalFetch = window.fetch.bind(window);
+        const ensureField = (obj, key, fallback) => { if (obj[key] == null) obj[key] = fallback; };
+        const fetchJsonOrEmpty = async (input, init) => {
+            try {
+                const resp = await originalFetch(input, init);
+                return await resp.json();
+            } catch (e) {
+                console.warn('[testImweb] real fetch failed, using fallback only', e);
+                return {};
+            }
+        };
+        const jsonResponse = (data) => new Response(
+            JSON.stringify(data),
+            { status: 200, headers: { 'Content-Type': 'application/json' } }
+        );
+
+        window.fetch = async function (input, init) {
+            const url = typeof input === 'string' ? input : (input && input.url) || '';
+
+            // Chatbot data: real fetch + memberOnlyAccess 주입 + 필수 필드 폴백
+            if (url.includes('/api/v1/chat/chatbot/')) {
+                const data = await fetchJsonOrEmpty(input, init);
+                ensureField(data, 'name', 'Gentoo Test');
+                ensureField(data, 'avatar', {
+                    floatingAsset: 'https://assets.gentooai.com/sdk/sdk-floating-close.png',
+                    profileAsset: 'https://assets.gentooai.com/sdk/sdk-floating-close.png',
+                });
+                ensureField(data, 'position', { web: { bottom: 100, right: 100 }, mobile: { bottom: 60, right: 0 } });
+                ensureField(data, 'mobilePosition', { bottom: 60, right: 0 });
+                ensureField(data, 'colorCode', [{ hex: '#222' }, { hex: '#444' }, { hex: '#666' }]);
+                ensureField(data, 'examples', ['배송 문의', '환불 정책', '제품 추천']);
+                const existingLoginUrl = (data.experimentalData || []).find(item => item.key === 'memberOnlyAccess')?.value;
+                data.experimentalData = (data.experimentalData || []).filter(item => item.key !== 'memberOnlyAccess');
+                data.experimentalData.push({
+                    key: 'memberOnlyAccess',
+                    activated: TEST_MODE === 'guestBlocked',
+                    value: existingLoginUrl,
+                });
+                return jsonResponse(data);
+            }
+
+            // Boot config: real fetch + 필수 필드 폴백
+            if (url.includes('/api/sdk/boot')) {
+                const data = await fetchJsonOrEmpty(input, init);
+                ensureField(data, 'floating', {});
+                if (data.floating.isVisible !== true && data.floating.isVisible !== false) data.floating.isVisible = true;
+                ensureField(data.floating, 'button', {});
+                ensureField(data.floating.button, 'imageUrl', 'https://assets.gentooai.com/sdk/sdk-floating-close.png');
+                ensureField(data.floating.button, 'comment', '안녕하세요 Gentoo입니다');
+                ensureField(data, 'greeting', { comment: [] });
+                return jsonResponse(data);
+            }
+
+            // Floating data (legacy, mobile): real fetch + 필수 필드 폴백
+            if (url.includes('/api/v1/chat/floating/')) {
+                const data = await fetchJsonOrEmpty(input, init);
+                ensureField(data, 'imageUrl', 'https://assets.gentooai.com/sdk/sdk-floating-close.png');
+                ensureField(data, 'comment', '안녕하세요 Gentoo입니다');
+                return jsonResponse(data);
+            }
+
+            // 그 외(api/v1/user, api/v1/event/* 등): real backend 통과
+            return originalFetch(input, init);
+        };
+    </script>
+
+    <!-- SDK loader (loads ./dist/imweb/* on localhost) -->
+    <script src="./sdk-imweb-test.js"></script>
+
+    <!-- Boot SDK -->
+    <script>
+        GentooIO('boot', { partnerType: 'imweb', testPartnerId: '68f6d753165ff8db3d070faf' });
+        GentooIO('init', {
+            position: {
+                web: { bottom: 100, right: 100 },
+                mobile: { bottom: 60, right: 0 },
+            },
+            showGentooButton: true,
+            isCustomButton: false,
+        });
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
## Summary

When chatbot `experimentalData` has `memberOnlyAccess.activated=true` and userType is `guest`, the SDK replaces the chat iframe with a "로그인 후 사용 가능합니다" view + login button. The button navigates to `memberOnlyAccess.value` (or current page URL as fallback when empty).

- Block decision: `userType === 'guest' && memberOnlyAccessActivated` (loginUrl is not part of the gate; absent value falls back to `window.location.href`)
- Floating button stays visible — only the chat content area is replaced
- iframe is hidden via `style.display = 'none'` and src is not set (no chat web load for blocked guests)
- Modal variants additionally skip input container / example chips

## Affected SDKs

| SDK | userType source | UI 분기 |
|---|---|---|
| imweb (desktop+modal) | `window.MEMBER_UID` | inline / shared modal |
| cafe24-glacier (desktop) | `member_id` (added) | inline |
| cafe24-modal (mobile) | `member_id` | shared modal |
| godomall (desktop+modal) | `getMemberProfile` | inline / shared modal |
| shopify-modal | `props.userType` (boot prop) | shared modal |

## Notes

- **Backend**: requires `chatbotData.experimentalData[memberOnlyAccess]` entry — already supported per backend team
- **Shopify**: requires Liquid template update to pass `userType: '{% if customer %}member{% else %}guest{% endif %}'` in boot props. Without this, `userType` is undefined → block never triggers (safe default)
- **dist/**: not committed — CI rebuilds with production env on merge to main
- **testPartnerId**: escape hatch added to imweb SDK (`floating-sdk-imweb.js`, `floating-sdk-imweb-modal.js`) so test pages can pass a real partnerId without going through `getImwebPartnerId` lookup. Logs a warning when used

## Test plan

- [ ] Verify imweb desktop + mobile via `testImweb.html` (mode=guestBlocked / guest / member)
- [ ] Verify cafe24 desktop (glacier) on real cafe24 dev store with backend-set `memberOnlyAccess`
- [ ] Verify cafe24 mobile (modal) on real cafe24 dev store
- [ ] Verify godomall desktop + mobile on real godomall dev store
- [ ] Verify shopify after Liquid update on test store
- [ ] Verify member users are NOT blocked when `memberOnlyAccess.activated=true`
- [ ] Verify guests are NOT blocked when `memberOnlyAccess.activated=false` or entry missing
- [ ] Verify login button → `memberOnlyAccess.value` URL
- [ ] Verify login button → current page URL (reload) when `value` is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added guest access control—non-logged-in users now see a login prompt instead of the chat widget
  * Enabled member-only access restriction with configurable login URL
  * Improved testing infrastructure for guest and member access scenarios across all platforms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->