### PR TITLE
fix: open chat directly for blocked guests on mobile floating click

### DIFF
--- a/src/utils/setupEventListenersModal.js
+++ b/src/utils/setupEventListenersModal.js
@@ -1,12 +1,13 @@
 import { postChatEventLog, postChatEventLogLegacy } from "../apis/chatConfig";
-import { 
-    updateFloatingContainerPosition, 
+import {
+    updateFloatingContainerPosition,
     updateIframeHeightByFooter,
     addLetter,
     logWindowWidth,
     injectViewport,
     deleteViewport
 } from "./floatingSdkUtils";
+import { isGuestAccessBlocked } from "./guestAccessBlock";
 
 export const setupEventListenersModal = (context, position) => {
     // Button click event
@@ -22,7 +23,7 @@ export const setupEventListenersModal = (context, position) => {
         // Inject viewport meta tag to block ios zoom in
         injectViewport(context, document);
 
-        if (context.messageExistence || context.displayLocation === 'PRODUCT_DETAIL') {
+        if (context.messageExistence || context.displayLocation === 'PRODUCT_DETAIL' || isGuestAccessBlocked(context)) {
             context.openChat();
             if (context?.eventCallback?.click) {
                 try { context.eventCallback.click(); } catch {}


### PR DESCRIPTION
## Summary

Follow-up fix for the memberOnlyAccess feature (#88, #89). On mobile, blocked guests saw only the dim layer and had no way to interact when clicking the floating button.

## Root cause

Mobile flow normally shows `inputContainer` (input + example chips) on the **first** floating button click — the chat iframe doesn't open until the user types or taps an example. For blocked guests, [createUIElementsModal](src/utils/createUIElementsModal.js) intentionally skips appending `inputContainer` to DOM (we don't want them interacting with chat input). This left the click handler with nothing visible to show.

## Fix

In [setupEventListenersModal.js:26](src/utils/setupEventListenersModal.js#L26), treat blocked guest the same as `messageExistence` / `PRODUCT_DETAIL` — skip the inputContainer step and call `openChat()` directly:

```diff
-if (context.messageExistence || context.displayLocation === 'PRODUCT_DETAIL') {
+if (context.messageExistence || context.displayLocation === 'PRODUCT_DETAIL' || isGuestAccessBlocked(context)) {
     context.openChat();
```

`openChat()` triggers `enableChat('shrink')` on mobile, which makes `iframeContainer` slide up. The block view is already inside `iframeContainer` and scales correctly via `height: calc(100% - 44px)`. Dragging the chat header up triggers `enableChat('full')` and the block view fills the full-height window — no extra changes needed since CSS handles both modes.

Chat requests are still not sent (iframe `display: none`, `src` not set).

## Test plan

- [ ] Mobile: floating button click → block view appears in shrink (modal-style) panel
- [ ] Mobile: drag chat header up → block view fills full height
- [ ] Mobile: tap login button → navigates to `memberOnlyAccess.value` (or current URL fallback)
- [ ] Mobile: tap close button → block view slides down, floating button returns
- [ ] Verify no chat-related network requests (no `chatroute/...` iframe load)

🤖 Generated with [Claude Code](https://claude.com/claude-code)