### PR TITLE
fix: prevent global button reset from making login button transparent on mobile

### DIFF
--- a/src/floating-sdk-modal.css
+++ b/src/floating-sdk-modal.css
@@ -816,7 +816,7 @@ div.chat-send-button {
     white-space: pre-line;
 }
 
-.guest-access-block-login-button {
+[data-gentoo-sdk="true"] .guest-access-block-login-button {
     font-family: "pretendard";
     font-size: 14px;
     font-weight: 600;
@@ -831,7 +831,7 @@ div.chat-send-button {
     transition: background 0.2s ease;
 }
 
-.guest-access-block-login-button:hover {
+[data-gentoo-sdk="true"] .guest-access-block-login-button:hover {
     background: #444;
 }
 


### PR DESCRIPTION
## Summary

Mobile-only fix for the memberOnlyAccess login button background.

## Root cause

[global.css:65-75](global.css#L65-L75) applies a baseline button reset:
\`\`\`css
[data-gentoo-sdk=\"true\"] input,
[data-gentoo-sdk=\"true\"] textarea,
[data-gentoo-sdk=\"true\"] button,
[data-gentoo-sdk=\"true\"] select {
    font: inherit !important;
    color: inherit;
    background: transparent;
    border: none;
    outline: none;
}
\`\`\`

The selector \`[data-gentoo-sdk=\"true\"] button\` has specificity (0,1,1), which beats my \`.guest-access-block-login-button\` rule (0,1,0). The login button's \`background: #222\` was overridden to \`transparent\`.

This only affected modal/mobile SDKs because they're the only ones that import global.css. Desktop SDKs don't import it, so they were unaffected.

## Fix

Prefix the rule with \`[data-gentoo-sdk=\"true\"]\` to bump specificity to (0,2,0) — same pattern as \`cs-inquiry-floating-button\` already uses in [floating-sdk-modal.css](src/floating-sdk-modal.css):

\`\`\`diff
-.guest-access-block-login-button {
+[data-gentoo-sdk=\"true\"] .guest-access-block-login-button {
     background: #222;
     ...
\`\`\`

## Test plan

- [ ] Mobile blocked guest: floating button → block view → login button shows dark background (#222) with white text
- [ ] Hover state still applies (#444)

🤖 Generated with [Claude Code](https://claude.com/claude-code)