### PR TITLE
Apply opt-in chat display location override

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "homepage": "https://waddle-corp.github.io/sdk-js-web/",
   "scripts": {
     "deploy": "gh-pages -d public",
+    "test": "node --test test/*.test.mjs",
     "build": "cross-env SDK_ENV=production webpack --config webpack.config.js --mode production",
     "build:dev": "cross-env SDK_ENV=development webpack --config webpack.config.js --mode development",
     "build:stage": "cross-env SDK_ENV=stage webpack --config webpack.config.js --mode development",

--- a/src/floating-sdk-imweb-modal.js
+++ b/src/floating-sdk-imweb-modal.js
@@ -21,6 +21,7 @@ import {
     checkSDKExists,
     isAllowedDomainForIframe
 } from './utils/floatingSdkUtils';
+import { resolveChatDisplayLocation } from './utils/chatDisplayLocation.mjs';
 
 class FloatingButton {
     constructor(props) {
@@ -131,6 +132,7 @@ class FloatingButton {
                     this.chatbotData = chatbotData;
                     this.floatingData = floatingData;
                     this.bootConfig = bootConfig;
+                    this.displayLocation = resolveChatDisplayLocation(bootConfig, this.displayLocation);
                     const warningMessageData = chatbotData?.experimentalData?.find(item => item.key === "warningMessage");
                     this.warningMessage = warningMessageData?.extra?.message;
                     this.warningActivated = warningMessageData?.activated;

--- a/src/floating-sdk-imweb.js
+++ b/src/floating-sdk-imweb.js
@@ -10,6 +10,7 @@ import {
 } from './apis/chatConfig';
 import { applyCanvasObjectFit } from './utils/floatingSdkUtils';
 import { buildGuestAccessBlockView, isGuestAccessBlocked } from './utils/guestAccessBlock';
+import { resolveChatDisplayLocation } from './utils/chatDisplayLocation.mjs';
 
 class FloatingButton {
     constructor(props) {
@@ -164,6 +165,7 @@ class FloatingButton {
                 .then(([chatbotData, bootConfig]) => {
                     this.chatbotData = chatbotData;
                     this.bootConfig = bootConfig;
+                    this.displayLocation = resolveChatDisplayLocation(bootConfig, this.displayLocation);
                     const warningMessageData = chatbotData?.experimentalData?.find(item => item.key === "warningMessage");
                     this.warningMessage = warningMessageData?.extra?.message;
                     this.warningActivated = warningMessageData?.activated;

--- a/src/utils/chatDisplayLocation.mjs
+++ b/src/utils/chatDisplayLocation.mjs
@@ -1,0 +1,10 @@
+export const CHAT_DISPLAY_LOCATIONS = new Set([
+    'HOME',
+    'PRODUCT_LIST',
+    'PRODUCT_DETAIL',
+]);
+
+export function resolveChatDisplayLocation(bootConfig, fallbackDisplayLocation) {
+    const override = bootConfig?.chat?.displayLocation;
+    return CHAT_DISPLAY_LOCATIONS.has(override) ? override : fallbackDisplayLocation;
+}

--- a/src/utils/chatDisplayLocation.mjs
+++ b/src/utils/chatDisplayLocation.mjs
@@ -1,8 +1,4 @@
-export const CHAT_DISPLAY_LOCATIONS = new Set([
-    'HOME',
-    'PRODUCT_LIST',
-    'PRODUCT_DETAIL',
-]);
+const CHAT_DISPLAY_LOCATIONS = new Set(['HOME', 'PRODUCT_LIST', 'PRODUCT_DETAIL']);
 
 export function resolveChatDisplayLocation(bootConfig, fallbackDisplayLocation) {
     const override = bootConfig?.chat?.displayLocation;

--- a/test/chatDisplayLocation.test.mjs
+++ b/test/chatDisplayLocation.test.mjs
@@ -3,13 +3,15 @@ import assert from 'node:assert/strict';
 import { resolveChatDisplayLocation } from '../src/utils/chatDisplayLocation.mjs';
 
 test('uses a supported Admin chat display-location override', () => {
-    assert.equal(
-        resolveChatDisplayLocation(
-            { chat: { displayLocation: 'HOME' } },
-            'PRODUCT_DETAIL',
-        ),
-        'HOME',
-    );
+    for (const displayLocation of ['HOME', 'PRODUCT_LIST', 'PRODUCT_DETAIL']) {
+        assert.equal(
+            resolveChatDisplayLocation(
+                { chat: { displayLocation } },
+                'PRODUCT_DETAIL',
+            ),
+            displayLocation,
+        );
+    }
 });
 
 test('keeps the SDK classification when the override is absent', () => {

--- a/test/chatDisplayLocation.test.mjs
+++ b/test/chatDisplayLocation.test.mjs
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveChatDisplayLocation } from '../src/utils/chatDisplayLocation.mjs';
+
+test('uses a supported Admin chat display-location override', () => {
+    assert.equal(
+        resolveChatDisplayLocation(
+            { chat: { displayLocation: 'HOME' } },
+            'PRODUCT_DETAIL',
+        ),
+        'HOME',
+    );
+});
+
+test('keeps the SDK classification when the override is absent', () => {
+    assert.equal(
+        resolveChatDisplayLocation({}, 'PRODUCT_DETAIL'),
+        'PRODUCT_DETAIL',
+    );
+});
+
+test('keeps the SDK classification for a custom display-location value', () => {
+    assert.equal(
+        resolveChatDisplayLocation(
+            { chat: { displayLocation: 'PRODUCT_DETAIL_SD' } },
+            'PRODUCT_DETAIL',
+        ),
+        'PRODUCT_DETAIL',
+    );
+});


### PR DESCRIPTION
## Summary
- consume the optional Boot `chat.displayLocation` override in Imweb desktop and modal SDKs
- apply only standard allowlisted locations to the chat iframe `dp` parameter
- preserve the existing local page classification when the override is absent or unsupported
- add focused resolver tests

## Why
Imweb board-detail URLs may include `idx` and be classified as product detail. Admin URL Mapping can now explicitly opt those pages into HOME chat behavior without customer-specific code.

## Impact
- no behavior change unless a matching URL Mapping explicitly supplies the override
- custom locations such as `PRODUCT_DETAIL_SD` fall back to the current SDK classification
- Cafe24 and Godomall SDK code is unchanged

## Validation
- `npm test`
- `npm run build:prod`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat display location can now be configured through supported settings.
  * Invalid or unsupported location values safely fall back to the existing SDK classification.

* **Bug Fixes**
  * Improved consistency for chat placement across supported application contexts.

* **Tests**
  * Added coverage for valid overrides, missing settings, and unsupported values.

* **Chores**
  * Added a standard test command for running the automated test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->