### PR TITLE
FastFive: collect Salesforce lead tracking fields

### DIFF
--- a/src/floating-sdk.js
+++ b/src/floating-sdk.js
@@ -57,6 +57,7 @@ class FloatingButton {
         this.displayLocation = props.displayLocation || "HOME";
         this.udid = props.udid || "";
         this.gentooSessionData = JSON.parse(sessionStorage.getItem('gentoo')) || {};
+        this.leadTracking = this.updateLeadTracking();
         // transitionPage(tp)를 제외한 모든 key가 null | undefined | ""이면 갱신 스킵
         // 단, transitionPage(tp)는 항상 최신 값으로 갱신
         if (props.utm && typeof props.utm === 'object') {
@@ -88,7 +89,8 @@ class FloatingButton {
         this.chatbotData;
         this.browserWidth = this.logWindowWidth();
         this.isSmallResolution = this.browserWidth < 601;
-        this.isMobileDevice = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
+        this.leadDeviceType = this.getLeadDeviceType();
+        this.isMobileDevice = this.leadDeviceType !== 'pc';
         this.isDestroyed = false;
         this.isInitialized = false; // Add flag to track initialization
         this.floatingCount = 0;
@@ -154,6 +156,47 @@ class FloatingButton {
             console.error(`Error during initialization: ${error}`);
             throw error;
         });
+    }
+
+    getLeadDeviceType() {
+        const userAgent = navigator.userAgent || '';
+        const isIPadOS = navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1;
+        const isTablet = isIPadOS
+            || /iPad|Tablet|PlayBook|Silk/i.test(userAgent)
+            || (/Android/i.test(userAgent) && !/Mobile/i.test(userAgent));
+
+        if (isTablet) return 'tablet';
+        if (/iPhone|iPod|Android|Mobile/i.test(userAgent)) return 'mobile';
+        return 'pc';
+    }
+
+    updateLeadTracking() {
+        const currentPage = window.location.pathname || '/';
+        const searchParams = new URLSearchParams(window.location.search);
+        const previousTracking = this.gentooSessionData.leadTracking || {};
+        const previousPage = previousTracking.conversionPage;
+        const leadTracking = {
+            landing: previousTracking.landing || currentPage,
+            conversionPage: currentPage,
+            prevConversionPage: previousTracking.prevConversionPage || '',
+            referrer: previousTracking.referrer ?? document.referrer ?? '',
+            gclid: searchParams.get('gclid') || previousTracking.gclid || '',
+        };
+
+        if (previousPage && previousPage !== currentPage) {
+            leadTracking.prevConversionPage = previousPage;
+        }
+
+        this.gentooSessionData.leadTracking = leadTracking;
+        sessionStorage.setItem('gentoo', JSON.stringify(this.gentooSessionData));
+        return leadTracking;
+    }
+
+    getLeadTrackingPayload() {
+        return {
+            ...this.leadTracking,
+            deviceType: this.leadDeviceType,
+        };
     }
 
     async init(params) {
@@ -333,6 +376,7 @@ class FloatingButton {
                     displayLocation: this.displayLocation,
                     deviceType: this.isMobileDevice ? "mobile" : "web",
                     fbclid: this.fbclid,
+                    leadTracking: this.getLeadTrackingPayload(),
                 }
             });
         }, 1000)
@@ -556,6 +600,7 @@ class FloatingButton {
                     displayLocation: this.displayLocation,
                     deviceType: this.isMobileDevice ? "mobile" : "web",
                     fbclid: this.fbclid,
+                    leadTracking: this.getLeadTrackingPayload(),
                 }
             });
         }, 1000);
@@ -1313,8 +1358,7 @@ window.FloatingButton = FloatingButton;
 
             // Add UTM parameters
             const parsedUrl = new URL(window.location.href);
-            const pathSegments = parsedUrl.pathname.split("/");
-            const transitionPage = "/" + pathSegments[1];
+            const transitionPage = parsedUrl.pathname || "/";
             const searchParams = new URLSearchParams(window.location.search);
             const utm = {
                 utms: searchParams.get("utm_source"),

--- a/src/floating-sdk.js
+++ b/src/floating-sdk.js
@@ -8,6 +8,7 @@ import {
 } from './apis/chatConfig';
 import Ff_fab_nopad from '../public/Ff_fab_nopad.lottie';
 import { applyCanvasObjectFit } from './utils/floatingSdkUtils';
+import { resolveLeadDeviceType, resolveLeadTracking } from './utils/leadTracking.mjs';
 
 
 class FloatingButton {
@@ -89,7 +90,7 @@ class FloatingButton {
         this.chatbotData;
         this.browserWidth = this.logWindowWidth();
         this.isSmallResolution = this.browserWidth < 601;
-        this.leadDeviceType = this.getLeadDeviceType();
+        this.leadDeviceType = resolveLeadDeviceType(navigator);
         this.isMobileDevice = this.leadDeviceType !== 'pc';
         this.isDestroyed = false;
         this.isInitialized = false; // Add flag to track initialization
@@ -158,38 +159,59 @@ class FloatingButton {
         });
     }
 
-    getLeadDeviceType() {
-        const userAgent = navigator.userAgent || '';
-        const isIPadOS = navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1;
-        const isTablet = isIPadOS
-            || /iPad|Tablet|PlayBook|Silk/i.test(userAgent)
-            || (/Android/i.test(userAgent) && !/Mobile/i.test(userAgent));
-
-        if (isTablet) return 'tablet';
-        if (/iPhone|iPod|Android|Mobile/i.test(userAgent)) return 'mobile';
-        return 'pc';
-    }
-
     updateLeadTracking() {
-        const currentPage = window.location.pathname || '/';
-        const searchParams = new URLSearchParams(window.location.search);
-        const previousTracking = this.gentooSessionData.leadTracking || {};
-        const previousPage = previousTracking.conversionPage;
-        const leadTracking = {
-            landing: previousTracking.landing || currentPage,
-            conversionPage: currentPage,
-            prevConversionPage: previousTracking.prevConversionPage || '',
-            referrer: previousTracking.referrer ?? document.referrer ?? '',
-            gclid: searchParams.get('gclid') || previousTracking.gclid || '',
-        };
-
-        if (previousPage && previousPage !== currentPage) {
-            leadTracking.prevConversionPage = previousPage;
-        }
+        const leadTracking = resolveLeadTracking(
+            this.gentooSessionData.leadTracking,
+            window.location,
+            document.referrer,
+        );
 
         this.gentooSessionData.leadTracking = leadTracking;
         sessionStorage.setItem('gentoo', JSON.stringify(this.gentooSessionData));
         return leadTracking;
+    }
+
+    setupLeadTrackingListeners() {
+        if (this.handleLeadLocationChange) return;
+
+        this.handleLeadLocationChange = () => {
+            this.leadTracking = this.updateLeadTracking();
+            if (!this.iframe?.contentWindow) return;
+
+            this.sendPostMessageHandler({
+                messageType: 'gentoo-statics',
+                contentData: { leadTracking: this.getLeadTrackingPayload() },
+            });
+        };
+        this.originalPushState = history.pushState;
+        this.originalReplaceState = history.replaceState;
+        this.patchedPushState = (...args) => {
+            const result = this.originalPushState.apply(history, args);
+            this.handleLeadLocationChange();
+            return result;
+        };
+        this.patchedReplaceState = (...args) => {
+            const result = this.originalReplaceState.apply(history, args);
+            this.handleLeadLocationChange();
+            return result;
+        };
+
+        history.pushState = this.patchedPushState;
+        history.replaceState = this.patchedReplaceState;
+        window.addEventListener('popstate', this.handleLeadLocationChange);
+    }
+
+    removeLeadTrackingListeners() {
+        if (!this.handleLeadLocationChange) return;
+
+        window.removeEventListener('popstate', this.handleLeadLocationChange);
+        if (history.pushState === this.patchedPushState) {
+            history.pushState = this.originalPushState;
+        }
+        if (history.replaceState === this.patchedReplaceState) {
+            history.replaceState = this.originalReplaceState;
+        }
+        this.handleLeadLocationChange = null;
     }
 
     getLeadTrackingPayload() {
@@ -360,6 +382,7 @@ class FloatingButton {
         }
         parentElem.appendChild(this.dimmedBackground);
         parentElem.appendChild(this.iframeContainer);
+        this.setupLeadTrackingListeners();
         requestAnimationFrame(() => this.updateIframeHeightByFooter());
 
         setTimeout(() => {
@@ -972,6 +995,7 @@ class FloatingButton {
 
         // Remove event listeners
         window.removeEventListener("resize", this.handleResize);
+        this.removeLeadTrackingListeners();
         if (this.button) {
             this.button.removeEventListener("click", this.buttonClickHandler);
         }

--- a/src/utils/leadTracking.mjs
+++ b/src/utils/leadTracking.mjs
@@ -1,0 +1,30 @@
+export function resolveLeadDeviceType(navigatorLike = {}) {
+    const userAgent = navigatorLike.userAgent || '';
+    const isIPadOS = navigatorLike.platform === 'MacIntel' && navigatorLike.maxTouchPoints > 1;
+    const isTablet = isIPadOS
+        || /iPad|Tablet|PlayBook|Silk/i.test(userAgent)
+        || (/Android/i.test(userAgent) && !/Mobile/i.test(userAgent));
+
+    if (isTablet) return 'tablet';
+    if (/iPhone|iPod|Android|Mobile/i.test(userAgent)) return 'mobile';
+    return 'pc';
+}
+
+export function resolveLeadTracking(previousTracking = {}, locationLike = {}, referrer = '') {
+    const currentPage = locationLike.pathname || '/';
+    const searchParams = new URLSearchParams(locationLike.search || '');
+    const previousPage = previousTracking.conversionPage;
+    const leadTracking = {
+        landing: previousTracking.landing || currentPage,
+        conversionPage: currentPage,
+        prevConversionPage: previousTracking.prevConversionPage || '',
+        referrer: previousTracking.referrer ?? referrer ?? '',
+        gclid: searchParams.get('gclid') || previousTracking.gclid || '',
+    };
+
+    if (previousPage && previousPage !== currentPage) {
+        leadTracking.prevConversionPage = previousPage;
+    }
+
+    return leadTracking;
+}

--- a/test/leadTracking.test.mjs
+++ b/test/leadTracking.test.mjs
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { resolveLeadDeviceType, resolveLeadTracking } from '../src/utils/leadTracking.mjs';
+
+test('keeps session acquisition data and updates SPA conversion pages', () => {
+    const firstPage = resolveLeadTracking(
+        undefined,
+        { pathname: '/landing', search: '?gclid=google-click-id' },
+        'https://www.google.com/',
+    );
+    const conversionPage = resolveLeadTracking(
+        firstPage,
+        { pathname: '/office/yeoksam', search: '' },
+        '',
+    );
+
+    assert.deepEqual(conversionPage, {
+        landing: '/landing',
+        conversionPage: '/office/yeoksam',
+        prevConversionPage: '/landing',
+        referrer: 'https://www.google.com/',
+        gclid: 'google-click-id',
+    });
+});
+
+test('classifies supported FastFive lead device types', () => {
+    assert.equal(resolveLeadDeviceType({ userAgent: 'Mozilla/5.0 (iPhone; Mobile)' }), 'mobile');
+    assert.equal(resolveLeadDeviceType({ userAgent: 'Mozilla/5.0 (Linux; Android 14; Tablet)' }), 'tablet');
+    assert.equal(resolveLeadDeviceType({ userAgent: 'Mozilla/5.0', platform: 'MacIntel', maxTouchPoints: 5 }), 'tablet');
+    assert.equal(resolveLeadDeviceType({ userAgent: 'Mozilla/5.0 (Macintosh)' }), 'pc');
+});


### PR DESCRIPTION
## Summary

- collect FastFive lead landing, conversion, previous conversion, referrer, gclid, and device type values
- keep conversion-page tracking current across SPA navigation
- forward tracking values to the chat iframe and cover the tracking rules with unit tests

## Why

The FastFive Salesforce lead contract now requires additional acquisition and conversion context. The previous SDK state was initialized only once, so client-side route changes could submit a stale conversion page.

## Impact

FastFive lead submissions receive current session and page context without changing the existing SDK behavior for other form fields.

## Checks

- `npm test` (6 passed)
- `npm run build:dev`
